### PR TITLE
Highlight Unity/Android problem in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple project showing how to use location services to measure speed. The sample app reports helpful data (location coordinates, accuracy, sampling timeframe)
 
+## Android 12 and Unity 2021 LTS compatible issue
+
+A bug came with some changes to Android 12 from Google in February which weren't compatible with Unity 2021 LTS location service backend and Unity didn't bother to fix it in 2021 and instead fixed it in Unity 2022. The bug makes Android phones not update it's location for several kilometers so make sure to use Unity 2022 when running this project on an Android 12 phone.
+
 ## Accuracy
 
 Deriving speed from location data works better at higher speed (say, over 20 km/h).


### PR DESCRIPTION
I've faced problems with Android 12 phones and Unity 2021 LTS with this awesome project and other Unity location services applications. Google made some changes to the GPS API in February to Android 12 which made Unity's location backend struggle to calculate new location data, it sometimes takes multiple kilometers for the next data point to be calculated so speedometers don't work after February this year in Unity 2021 (I haven't tested older Unity versions). Unity didn't bother to fix this in Unity 2021 and fixed it in Unity 2022 so building this project with Unity 2022.1.10f1 on my Samsung Note 20 Ultra worked as expected again. (Found the solution here if you want to read more: https://github.com/mapbox/mapbox-unity-sdk/issues/1850)

So I thought it would be great to add this information to the README file so other developers don't open this amazing project in Unity 2021 and find it not working which leaves them in frustration and skipping the project (which I was close to doing xD).
Thanks a lot for this gold chest of scripts!!!!